### PR TITLE
:note: Fix link in readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ After forking this project in `Github`, run these commands:
 
 ```bash
 ## clone this repo to a local directory
-git clone https://github.com/<your-username>/cypress-example-phonecat.git
+git clone https://github.com/cypress-io/cypress-example-phonecat.git
 
 ## cd into the cloned repo
 cd cypress-example-phonecat


### PR DESCRIPTION
Trivial change:

That is very easy to not spot the wrong link when using COPY/PASTE.

Thanks!