### PR TITLE
test: fix typo in test which prevented assertions from working

### DIFF
--- a/cypress/integration/app_spec.js
+++ b/cypress/integration/app_spec.js
@@ -28,18 +28,18 @@ describe('PhoneCat Application', function() {
       cy.get('@q').type('tablet')
       cy.ng('binding', 'phone.name')
         .should(function($names){
-          expect(getNames($names)).to.deep.eq [
+          expect(getNames($names)).to.deep.eq([
             'Motorola XOOM™ with Wi-Fi',
             'MOTOROLA XOOM™'
-          ]
+          ])
         })
       cy.ng('model', '$ctrl.orderProp').select('name')
       cy.ng('binding', 'phone.name')
         .should(function($names){
-          expect(getNames($names)).to.deep.eq [
+          expect(getNames($names)).to.deep.eq([
             'MOTOROLA XOOM™',
             'Motorola XOOM™ with Wi-Fi'
-          ]
+          ])
         })
     })
 


### PR DESCRIPTION
A quick fix which adds parentheses around the function calls to actually assert some behavior in the test. I didn't see a Contributing guideline, so please let me know if you need any more information. Thanks!